### PR TITLE
Fix broken internal "elements" link

### DIFF
--- a/docs/Ronivans Legacy/Content/Chemical Processing - Biochemistry/index.md
+++ b/docs/Ronivans Legacy/Content/Chemical Processing - Biochemistry/index.md
@@ -4,5 +4,5 @@
 
 This is a variant of Chemical Processing mod focused on organics and green chemistry.
 
-- [New Elements and critter diet changes](./Elements).
+- [New Elements and critter diet changes](./elements).
 - [New Buildings](./Buildings).


### PR DESCRIPTION
Paths in the generated HTML are case-sensitive; this fixes an incorrectly capitalised link so that it now works as expected.